### PR TITLE
Fixed base entity deinitialise call

### DIFF
--- a/lua/entities/base_starfall_entity/init.lua
+++ b/lua/entities/base_starfall_entity/init.lua
@@ -17,7 +17,7 @@ function ENT:OnRemove ()
 	hook.Run( "sf_deinitialize", self:EntIndex( ) )
 	self:runScriptHook( "Removed" )
 
-	self.instance:deinitialize()
+	if self.instance then self.instance:deinitialize() end
 	self.instance = nil
 end
 


### PR DESCRIPTION
Base entity would call deinitialise without checking if instance
existed. With new removed hook, if an error is thrown and the instance
deinitialised during that remove hook, then instance would no longer
exist, and a lua error would occur.